### PR TITLE
fix Deprecated

### DIFF
--- a/lib/RedAnt/TwigComponents/Registry.php
+++ b/lib/RedAnt/TwigComponents/Registry.php
@@ -47,7 +47,7 @@ class Registry
      * @param Environment                    $twig
      * @param PropertyAccessorInterface|null $propertyAccessor
      */
-    public function __construct(Environment $twig, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct(Environment $twig, ?PropertyAccessorInterface $propertyAccessor = null)
     {
         $this->twig = $twig;
 


### PR DESCRIPTION
Fix in 8.4 php

```
( ! ) Deprecated: RedAnt\TwigComponents\Registry::__construct(): Implicitly marking parameter $propertyAccessor as nullable is deprecated, the explicit nullable type must be used instead in /vendor/redant/twig-components/lib/RedAnt/TwigComponents/Registry.php on line 50
```